### PR TITLE
Fix compile warnings and scan behavior

### DIFF
--- a/components/wifi_controller/wifi_controller.c
+++ b/components/wifi_controller/wifi_controller.c
@@ -18,9 +18,15 @@ static const char* TAG = "wifi_controller";
 static bool wifi_init = false;
 static uint8_t original_mac_ap[6];
 
+/*
+ * Event handler placeholder for future Wi-Fi events.
+ * Currently not used but kept for potential extensions.
+ */
+#if 0
 static void wifi_event_handler(void *event_handler_arg, esp_event_base_t event_base, int32_t event_id, void *event_data){
 
 }
+#endif
 
 /**
  * @brief Initializes Wi-Fi interface into APSTA mode and starts it.

--- a/main/attack.c
+++ b/main/attack.c
@@ -168,7 +168,7 @@ static void attack_request_handler(void *args, esp_event_base_t event_base, int3
     vTaskDelay(pdMS_TO_TICKS(500));
 
     for (int i = 0; i < attack_request->num_aps; i++) {
-        wifi_ap_record_t *ap_record = wifictl_get_ap_record(attack_request->ap_ids[i]);
+        const wifi_ap_record_t *ap_record = wifictl_get_ap_record(attack_request->ap_ids[i]);
         if (ap_record) {
             attack_config.ap_records[i] = *ap_record;
             //ESP_LOGI(TAG, "Stored AP Record [%d]: SSID: %s, RSSI: %d", i, ap_record->ssid, ap_record->rssi);

--- a/main/main.c
+++ b/main/main.c
@@ -65,6 +65,9 @@ static void print_ap_list_flipper_band(void){
 static void scan_loop_task(void *pv){
     while(scan_running){
         wifictl_scan_nearby_aps();
+        if(!scan_running){
+            break;
+        }
         print_ap_list_flipper_band();
         vTaskDelay(pdMS_TO_TICKS(1700));
     }


### PR DESCRIPTION
## Summary
- silence unused wifi event handler warning
- use const ap_record pointer
- stop printing scan results after `scanstop`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d09ba4ac832fa0fc471ba17642dd