### PR TITLE
Fix WiFi startup warning

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -16,6 +16,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/uart.h"
+#include "nvs_flash.h"
 
 #define LOG_LOCAL_LEVEL ESP_LOG_VERBOSE
 #include "esp_log.h"
@@ -215,6 +216,13 @@ static void cli_task(void *pv){
 void app_main(void)
 {
     ESP_LOGD(TAG, "app_main started");
+    // Initialize NVS to store Wi-Fi calibration data
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
     const uart_config_t uart_config = {


### PR DESCRIPTION
## Summary
- init NVS during app startup to avoid WiFi calibration warnings

## Testing
- `make help` *(fails: No rule to make target 'help')*

------
https://chatgpt.com/codex/tasks/task_e_6843353c75ac832f956253b8343ab7a3