### PR TITLE
Fix target list layout and implement scrolling

### DIFF
--- a/FliperApp/README.md
+++ b/FliperApp/README.md
@@ -20,7 +20,7 @@ Shows list of selected targets.
 
 ### Targets screen
 
-Shows up to six networks at once. Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
+Shows up to five networks at once. Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
 
 The application communicates over UART using the default Flipper settings. It automatically reboots the ESP32 and clears pending console output on start so no stray characters are sent.
 

--- a/FliperApp/README.md
+++ b/FliperApp/README.md
@@ -20,7 +20,7 @@ Shows list of selected targets.
 
 ### Targets screen
 
-Shows up to five networks at once. Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
+Shows up to five networks at once. Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **LEFT**/**RIGHT** to manually scroll the highlighted name. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
 
 The application communicates over UART using the default Flipper settings. It automatically reboots the ESP32 and clears pending console output on start so no stray characters are sent.
 

--- a/FliperApp/application.fam
+++ b/FliperApp/application.fam
@@ -3,7 +3,7 @@ App(
     name="ESP32 Tool",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="scan_app",
-    stack_size=2 * 1024,
+    stack_size=4 * 1024,
     fap_version="1.0",
     fap_author="Czech5",
     fap_description="Scan Wi-Fi and launch attacks via UART",

--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -255,6 +255,21 @@ static void scan_app_input_callback(InputEvent* event, void* ctx) {
                 app->target_scroll_tick = 0;
                 if(app->selected_target >= app->target_scroll + TARGET_VISIBLE_LINES) app->target_scroll++;
                 view_port_update(app->viewport);
+            } else if(event->key == InputKeyLeft) {
+                if(app->target_name_offset > 0) {
+                    app->target_name_offset--;
+                    app->target_scroll_tick = 0;
+                    view_port_update(app->viewport);
+                }
+            } else if(event->key == InputKeyRight) {
+                size_t len = strlen(app->networks[app->selected_target]);
+                size_t max_offset = 0;
+                if(len > TARGET_DISPLAY_CHARS - 2) max_offset = len - (TARGET_DISPLAY_CHARS - 2);
+                if(app->target_name_offset < max_offset) {
+                    app->target_name_offset++;
+                    app->target_scroll_tick = 0;
+                    view_port_update(app->viewport);
+                }
             } else if(event->key == InputKeyOk) {
                 app->target_selected[app->selected_target] = !app->target_selected[app->selected_target];
                 view_port_update(app->viewport);

--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -6,7 +6,8 @@
 #include <furi_hal_serial.h>
 
 #define TARGET_VISIBLE_LINES 5
-#define TARGET_DISPLAY_CHARS 16
+// Display width in characters including cursor and selection marker
+#define TARGET_DISPLAY_CHARS 21
 #define SCROLL_STEP_DELAY 5
 
 // strncat is disabled in Flipper firmware API, so implement a minimal

--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -2,6 +2,7 @@
 #include <gui/gui.h>
 #include <input/input.h>
 #include <string.h>
+#include <stdio.h>
 #include <furi_hal.h>
 #include <furi_hal_serial.h>
 


### PR DESCRIPTION
## Summary
- update Flipper app README to note only five targets fit on screen
- support five visible rows in targets list
- implement horizontal scrolling for long target names

## Testing
- `cmake ..` *(fails: include could not find file)*

------
https://chatgpt.com/codex/tasks/task_e_684363f0f5d0832fa4ef4f894d938249