### PR TITLE
Flush UART on app startup

### DIFF
--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -329,7 +329,11 @@ int32_t scan_app(void* p) {
     furi_hal_serial_tx_wait_complete(app.serial);
     furi_delay_ms(500);
 
+    /* Start UART reception and discard any boot output */
     furi_hal_serial_async_rx_start(app.serial, uart_rx_cb, &app, false);
+    while(furi_hal_serial_async_rx_available(app.serial)) {
+        furi_hal_serial_async_rx(app.serial);
+    }
 
     Gui* gui = furi_record_open(RECORD_GUI);
     app.viewport = view_port_alloc();


### PR DESCRIPTION
## Summary
- clear any pending serial data after rebooting the ESP32 from the Flipper app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857c2efd0b4832f8f0f47711b695476