### PR TITLE
Fix flipper app crash by reducing stack usage

### DIFF
--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -295,20 +295,9 @@ static void scan_app_input_callback(InputEvent* event, void* ctx) {
 
 int32_t scan_app(void* p) {
     (void)p;
-    ScanApp app = {
-        .scanning=false,
-        .stop_requested=false,
-        .exit_app=false,
-        .attacking=false,
-        .menu_index=0,
-        .target_scroll=0,
-        .selected_target=0,
-        .target_name_offset=0,
-        .target_scroll_tick=0,
-        .network_count=0,
-        .line_pos=0,
-        .screen=ScreenMainMenu,
-        .serial=NULL};
+    static ScanApp app; // allocate in BSS to reduce stack usage
+    memset(&app, 0, sizeof(app));
+    app.screen = ScreenMainMenu;
 
     app.serial = furi_hal_serial_control_acquire(FuriHalSerialIdUsart);
     if(!app.serial) {


### PR DESCRIPTION
## Summary
- use static `ScanApp` instance to avoid large stack allocation

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file `/tools/cmake/project.cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_6857c4925000832f821fbd7518898a80