### PR TITLE
docs: add flipper debugging instructions

### DIFF
--- a/FliperApp/DEBUGGING.md
+++ b/FliperApp/DEBUGGING.md
@@ -1,0 +1,26 @@
+# Debugging the Flipper Zero App
+
+This app is built with the standard `fbt`/`ufbt` tooling from the official firmware.
+Using these tools you can flash the app and view logs to track down crashes.
+
+## Quick steps
+
+1. Build the app from the firmware directory:
+   ```bash
+   ./fbt fap_scan_app
+   ```
+2. Flash it to the device over USB:
+   ```bash
+   ./fbt flash_usb
+   ```
+3. Open the log console to watch UART output:
+   ```bash
+   ./fbt log
+   ```
+4. For step-by-step debugging attach GDB:
+   ```bash
+   ./fbt debug
+   ```
+
+Refer to the [`fbt` documentation](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/fbt.md) for more options.
+

--- a/FliperApp/DEBUGGING.md
+++ b/FliperApp/DEBUGGING.md
@@ -24,3 +24,9 @@ Using these tools you can flash the app and view logs to track down crashes.
 
 Refer to the [`fbt` documentation](https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/fbt.md) for more options.
 
+
+## Troubleshooting
+
+If `ufbt debug` prints "Remote communication error" or "Cannot access memory", the SWD connection failed to attach. Verify that the debug adapter (ST-Link or Flipper debug board) is properly connected and recognized by the OS. Try powering the Flipper off and on again before starting `ufbt debug`.
+
+You should run debugging commands from the firmware root and keep the USB cable connected for both power and ST-Link. If OpenOCD still reports errors, check the `openocd.log` file in the `scripts/debug` directory for more detail.

--- a/FliperApp/README.md
+++ b/FliperApp/README.md
@@ -46,3 +46,21 @@ tree.
 For a more advanced example of UART usage see the
 [uart_demo](https://github.com/jamisonderek/flipper-zero-tutorials/tree/main/gpio/uart_demo)
 project referenced in Flipper Zero community tutorials.
+
+## Debugging
+
+If the application crashes or behaves unexpectedly you can gather logs using the
+tools provided with the firmware sources. From the firmware directory run:
+
+```bash
+./fbt flash_usb   # upload the build
+./fbt log         # view runtime logs
+```
+
+For step-by-step debugging you can invoke:
+
+```bash
+./fbt debug
+```
+
+More details can be found in [DEBUGGING.md](DEBUGGING.md).

--- a/FliperApp/README.md
+++ b/FliperApp/README.md
@@ -64,3 +64,4 @@ For step-by-step debugging you can invoke:
 ```
 
 More details can be found in [DEBUGGING.md](DEBUGGING.md).
+For common connection problems see the "Troubleshooting" section in [DEBUGGING.md](DEBUGGING.md).


### PR DESCRIPTION
## Summary
- document how to capture logs and use gdb on the Flipper

## Testing
- `make -n` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857cd8caefc832fa655c0250ac03e25