### PR TITLE
Extend boot wait time for ESP32

### DIFF
--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -317,11 +317,14 @@ int32_t scan_app(void* p) {
     furi_hal_serial_tx(app.serial, (const uint8_t*)reboot_cmd, strlen(reboot_cmd));
     furi_hal_serial_tx_wait_complete(app.serial);
     /* allow ESP32 to reboot fully */
-    furi_delay_ms(1000);
+    // ESP32-C5 boot time increased on recent firmware versions.
+    // Wait longer to ensure the module finishes rebooting before
+    // enabling UART reception to avoid Furi check failures.
+    furi_delay_ms(4000);
 
     /* Start UART reception and discard any remaining boot output */
     furi_hal_serial_async_rx_start(app.serial, uart_rx_cb, &app, false);
-    for(int i = 0; i < 100; i++) {
+    for(int i = 0; i < 400; i++) {
         while(furi_hal_serial_async_rx_available(app.serial)) {
             furi_hal_serial_async_rx(app.serial);
         }


### PR DESCRIPTION
## Summary
- wait longer for ESP32 reboot when launching Flipper app
- drain serial for additional time after reboot

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_6857f01038e0832f95ab4da19a363362