### PR TITLE
Improve Wi‑Fi scan output

### DIFF
--- a/FliperApp/README.md
+++ b/FliperApp/README.md
@@ -20,7 +20,7 @@ Shows list of selected targets.
 
 ### Targets screen
 
-Shows up to five networks at once. Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **LEFT**/**RIGHT** to manually scroll the highlighted name. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
+Shows up to five networks at once. Each entry displays the band, SSID and encryption (e.g. `2.4G MyAP WPA2`). Use **UP**/**DOWN** to move the cursor – the list scrolls automatically. Press **LEFT**/**RIGHT** to manually scroll the highlighted name. Press **OK** to toggle selection of a network. Selected entries are marked with `*`. **BACK** returns to the menu.
 
 The application communicates over UART using the default Flipper settings. It clears any pending console output on start so no stray characters are sent.
 

--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -85,12 +85,13 @@ static void uart_rx_cb(FuriHalSerialHandle* handle, FuriHalSerialRxEvent event, 
                     }
 
                     char entry[48];
-                    snprintf(entry, sizeof(entry), "%s ", band);
-                    safe_strlcat(entry, essid, sizeof(entry));
+                    snprintf(entry, sizeof(entry), "%s %s ", band, essid);
+                    safe_strlcat(entry, auth, sizeof(entry));
                     strncpy(app->networks[app->network_count], entry, 47);
                     app->networks[app->network_count][47] = '\0';
 
-                    if(strncmp(auth, "WPA3", 4) == 0) app->count_wpa3++;
+                    if(strncmp(auth, "WPA2/WPA3", 9) == 0) app->count_wpa3++;
+                    else if(strncmp(auth, "WPA3", 4) == 0) app->count_wpa3++;
                     else if(strncmp(auth, "WPA2", 4) == 0) app->count_wpa2++;
                     else if(strncmp(auth, "WPA", 3) == 0) app->count_wpa++;
                     else app->count_open++;

--- a/main/main.c
+++ b/main/main.c
@@ -79,12 +79,14 @@ static void print_ap_list_flipper_band(void){
                 break;
 #ifdef WIFI_AUTH_WPA3_PSK
             case WIFI_AUTH_WPA3_PSK:
+                enc = "WPA3";
+                break;
 #endif
 #ifdef WIFI_AUTH_WPA2_WPA3_PSK
             case WIFI_AUTH_WPA2_WPA3_PSK:
-#endif
-                enc = "WPA3";
+                enc = "WPA2/WPA3";
                 break;
+#endif
             default:
                 break;
         }


### PR DESCRIPTION
## Summary
- show band, SSID and encryption in Flipper app target list
- report WPA2/WPA3 networks correctly

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584011dc14832f9b79a7fb5aa91a31