### PR TITLE
Fix buffer truncation in Flipper app

### DIFF
--- a/FliperApp/scan_app.c
+++ b/FliperApp/scan_app.c
@@ -85,7 +85,9 @@ static void uart_rx_cb(FuriHalSerialHandle* handle, FuriHalSerialRxEvent event, 
                     }
 
                     char entry[48];
-                    snprintf(entry, sizeof(entry), "%s %s ", band, essid);
+                    snprintf(entry, sizeof(entry), "%s ", band);
+                    safe_strlcat(entry, essid, sizeof(entry));
+                    safe_strlcat(entry, " ", sizeof(entry));
                     safe_strlcat(entry, auth, sizeof(entry));
                     strncpy(app->networks[app->network_count], entry, 47);
                     app->networks[app->network_count][47] = '\0';


### PR DESCRIPTION
## Summary
- avoid snprintf truncation for SSIDs in Flipper app

## Testing
- `ufbt fap_scan_app` *(fails: SDK download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68584386019c832fa7411aa425264a62