### PR TITLE
Remove unused variables causing build warnings

### DIFF
--- a/main/led_status.c
+++ b/main/led_status.c
@@ -2,8 +2,6 @@
 #include "esp_log.h"
 #include "freertos/task.h"
 
-static const char* TAG = "led_status";
-
 static led_strip_handle_t led_strip;
 static led_state_t current_state = LED_STATE_BOOT;
 

--- a/main/st7789.c
+++ b/main/st7789.c
@@ -434,7 +434,6 @@ static void st7789_send_color(void * data, size_t length)
 {
 	static uint8_t buf_c[SIZE_B];
 	uint8_t *data_i = data;
-	int asd = (uint8_t)data_i[0];
     disp_wait_for_pending_transactions();
     gpio_set_level(ST7789_DC, 1);
     for(int idx = 0; idx < length ; idx +=2){		//Invert color bytes


### PR DESCRIPTION
## Summary
- remove `asd` variable from `st7789.c`
- remove unused logging tag from `led_status.c`

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_6872b2e25f2c832f8e3b06d6bc320a4d